### PR TITLE
Feature improve unit tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -145,10 +145,17 @@
   packages = [
     ".",
     "ext",
-    "log"
+    "log",
+    "mocktracer"
   ]
   revision = "1949ddbfd147afd4d964a9f00b24eb291e0e7c38"
   version = "v1.0.2"
+
+[[projects]]
+  name = "github.com/phayes/freeport"
+  packages = ["."]
+  revision = "b8543db493a5ed890c5499e935e2cad7504f3a04"
+  version = "1.0.2"
 
 [[projects]]
   name = "github.com/pkg/errors"
@@ -251,7 +258,8 @@
     "idna",
     "internal/timeseries",
     "lex/httplex",
-    "trace"
+    "trace",
+    "websocket"
   ]
   revision = "d41e8174641f662c5a2d1c7a5f9e828788eb8706"
 
@@ -344,6 +352,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c174ebb220480d2af4def49e3ee5f1c192015914821cbf83688dd3ebe227f3ef"
+  inputs-digest = "58a9f66c2462f101e47f6dfb58846868a708de47c09abb06538b914d69af63c6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/grpc/tracing_test.go
+++ b/grpc/tracing_test.go
@@ -2,9 +2,6 @@ package server_test
 
 import (
 	"context"
-	"fmt"
-	"log"
-	"net"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -35,33 +32,3 @@ var _ = Describe("Tracing", func() {
 		Expect(len(tracer.FinishedSpans())).To(Equal(1))
 	})
 })
-
-func runMockTracingServer(ctx context.Context, addr string, buf []byte) error {
-
-	serverAddr, err := net.ResolveUDPAddr("udp", addr)
-	if err != nil {
-		log.Println(err.Error())
-		return err
-	}
-	listener, err := net.ListenUDP("udp", serverAddr)
-	if err != nil {
-		log.Println(err.Error())
-		return err
-	}
-	defer listener.Close()
-	for {
-		select {
-		case <-ctx.Done():
-			{
-				return ctx.Err()
-			}
-		default:
-			{
-				_, _, err := listener.ReadFromUDP(buf[:])
-				if err != nil {
-					fmt.Println("Error: ", err)
-				}
-			}
-		}
-	}
-}

--- a/http/cors_test.go
+++ b/http/cors_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/http/httptest"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -24,10 +25,8 @@ var _ = Describe("CORS", func() {
 		allowCredentials := true
 		srv, err := createServer([]Option{WithCORS(allowedOrigins, allowedMethods, allowedHeaders, allowCredentials)})
 		Expect(err).NotTo(HaveOccurred())
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		go ListenAndServe(ctx, ":4004", srv)
-		req, _ := http.NewRequest(http.MethodOptions, "http://localhost:4004", nil)
+		ts := httptest.NewServer(srv.Handler)
+		req, _ := http.NewRequest(http.MethodOptions, ts.URL+"/cors", nil)
 		req.Header.Set("Access-Control-Request-Method", "HEAD")
 		req.Header.Set("Origin", "foo.bar")
 		resp, err := http.DefaultClient.Do(req)

--- a/http/http_suite_test.go
+++ b/http/http_suite_test.go
@@ -2,8 +2,11 @@ package server_test
 
 import (
 	"io"
+	"log"
 	"net/http"
 	"testing"
+
+	"golang.org/x/net/websocket"
 
 	httpserver "github.com/contiamo/goserver/http"
 	. "github.com/onsi/ginkgo"
@@ -16,13 +19,20 @@ func TestHttp(t *testing.T) {
 }
 
 func createServer(opts []httpserver.Option) (*http.Server, error) {
+	mux := http.NewServeMux()
+	mux.Handle("/ws/", websocket.Handler(func(ws *websocket.Conn) {
+		io.Copy(ws, ws)
+	}))
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/panic" {
+			panic("PANIC!!!")
+		}
+		log.Println("Got request to " + r.URL.Path)
+		io.Copy(w, r.Body)
+	})
+
 	return httpserver.New(&httpserver.Config{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/panic" {
-				panic("PANIC!!!")
-			}
-			io.Copy(w, r.Body)
-		}),
+		Handler: mux,
 		Options: opts,
 	})
 }

--- a/http/logging_test.go
+++ b/http/logging_test.go
@@ -2,8 +2,8 @@ package server_test
 
 import (
 	"bytes"
-	"context"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
@@ -19,10 +19,8 @@ var _ = Describe("Logging", func() {
 		logrus.SetOutput(buf)
 		srv, err := createServer([]Option{WithLogging("test")})
 		Expect(err).NotTo(HaveOccurred())
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		go ListenAndServe(ctx, ":4001", srv)
-		_, err = http.Get("http://localhost:4001")
+		ts := httptest.NewServer(srv.Handler)
+		_, err = http.Get(ts.URL + "/logging")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(strings.Contains(buf.String(), "completed handling request")).To(BeTrue())
 	})

--- a/http/logging_test.go
+++ b/http/logging_test.go
@@ -20,8 +20,23 @@ var _ = Describe("Logging", func() {
 		srv, err := createServer([]Option{WithLogging("test")})
 		Expect(err).NotTo(HaveOccurred())
 		ts := httptest.NewServer(srv.Handler)
+		defer ts.Close()
 		_, err = http.Get(ts.URL + "/logging")
 		Expect(err).NotTo(HaveOccurred())
+		Expect(strings.Contains(buf.String(), "completed handling request")).To(BeTrue())
+	})
+
+	It("should support websockets", func() {
+		buf := &bytes.Buffer{}
+		logrus.SetOutput(buf)
+		srv, err := createServer([]Option{WithLogging("test")})
+		Expect(err).NotTo(HaveOccurred())
+		ts := httptest.NewServer(srv.Handler)
+		defer ts.Close()
+
+		err = testWebsocketEcho(ts.URL)
+		Expect(err).NotTo(HaveOccurred())
+
 		Expect(strings.Contains(buf.String(), "completed handling request")).To(BeTrue())
 	})
 })

--- a/http/metrics_test.go
+++ b/http/metrics_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Metrics", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		go ListenAndServe(ctx, ":4002", srv)
-		_, err = http.Get("http://localhost:4002")
+		_, err = http.Get("http://localhost:4002/metrics_test")
 		Expect(err).NotTo(HaveOccurred())
 		go goserver.ListenAndServeMetricsAndHealth(":8080", nil)
 		resp, err := http.Get("http://localhost:8080/metrics")

--- a/http/metrics_test.go
+++ b/http/metrics_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
@@ -22,6 +23,23 @@ var _ = Describe("Metrics", func() {
 		go ListenAndServe(ctx, ":4002", srv)
 		_, err = http.Get("http://localhost:4002/metrics_test")
 		Expect(err).NotTo(HaveOccurred())
+		go goserver.ListenAndServeMetricsAndHealth(":8080", nil)
+		resp, err := http.Get("http://localhost:8080/metrics")
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+		bs, _ := ioutil.ReadAll(resp.Body)
+		Expect(strings.Contains(string(bs), `latencies_bucket{code="200",method="get",service="test",le="+Inf"} 1`))
+	})
+
+	It("should support websockets", func() {
+		srv, err := createServer([]Option{WithMetrics("test")})
+		Expect(err).NotTo(HaveOccurred())
+		ts := httptest.NewServer(srv.Handler)
+		defer ts.Close()
+
+		err = testWebsocketEcho(ts.URL)
+		Expect(err).NotTo(HaveOccurred())
+
 		go goserver.ListenAndServeMetricsAndHealth(":8080", nil)
 		resp, err := http.Get("http://localhost:8080/metrics")
 		Expect(err).NotTo(HaveOccurred())

--- a/http/recovery_test.go
+++ b/http/recovery_test.go
@@ -1,9 +1,9 @@
 package server_test
 
 import (
-	"context"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -17,10 +17,8 @@ var _ = Describe("Recovery", func() {
 		logrus.SetOutput(ioutil.Discard)
 		srv, err := createServer([]Option{WithRecovery(ioutil.Discard, true)})
 		Expect(err).NotTo(HaveOccurred())
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		go ListenAndServe(ctx, ":4003", srv)
-		resp, err := http.Get("http://localhost:4003/panic")
+		ts := httptest.NewServer(srv.Handler)
+		resp, err := http.Get(ts.URL + "/panic")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
 	})

--- a/http/recovery_test.go
+++ b/http/recovery_test.go
@@ -18,8 +18,20 @@ var _ = Describe("Recovery", func() {
 		srv, err := createServer([]Option{WithRecovery(ioutil.Discard, true)})
 		Expect(err).NotTo(HaveOccurred())
 		ts := httptest.NewServer(srv.Handler)
+		defer ts.Close()
 		resp, err := http.Get(ts.URL + "/panic")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
+	})
+
+	It("should support websockets and tracing", func() {
+		logrus.SetOutput(ioutil.Discard)
+		srv, err := createServer([]Option{WithRecovery(ioutil.Discard, true)})
+		Expect(err).NotTo(HaveOccurred())
+		ts := httptest.NewServer(srv.Handler)
+		defer ts.Close()
+
+		err = testWebsocketEcho(ts.URL)
+		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/http/tracing_test.go
+++ b/http/tracing_test.go
@@ -1,60 +1,28 @@
 package server_test
 
 import (
-	"context"
-	"fmt"
-	"net"
 	"net/http"
-	"time"
+	"net/http/httptest"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
 
 	. "github.com/contiamo/goserver/http"
 )
 
 var _ = Describe("Tracing", func() {
+	tracer := mocktracer.New()
+	opentracing.SetGlobalTracer(tracer)
+
 	It("should be possible to setup tracing", func() {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		go runMockTracingServer(ctx, ":1234")
-		srv, err := createServer([]Option{WithTracing("localhost:1234", "test")})
+		srv, err := createServer([]Option{WithTracing("localhost:test", "test")})
 		Expect(err).NotTo(HaveOccurred())
-		go ListenAndServe(ctx, ":4004", srv)
-		_, err = http.Get("http://localhost:4004")
+		ts := httptest.NewServer(srv.Handler)
+		_, err = http.Get(ts.URL + "/tracing")
 		Expect(err).NotTo(HaveOccurred())
-		time.Sleep(1 * time.Second) // wait for span to be transmitted
-		Expect(receivedSomething).To(BeTrue())
+
+		Expect(len(tracer.FinishedSpans())).To(Equal(1))
 	})
 })
-
-var receivedSomething bool
-
-func runMockTracingServer(ctx context.Context, addr string) error {
-	serverAddr, err := net.ResolveUDPAddr("udp", addr)
-	if err != nil {
-		return err
-	}
-	listener, err := net.ListenUDP("udp", serverAddr)
-	if err != nil {
-		return err
-	}
-	defer listener.Close()
-	buf := make([]byte, 1024)
-	for {
-		select {
-		case <-ctx.Done():
-			{
-				return ctx.Err()
-			}
-		default:
-			{
-				_, _, err := listener.ReadFromUDP(buf[:])
-				receivedSomething = true
-				if err != nil {
-					fmt.Println("Error: ", err)
-				}
-			}
-		}
-	}
-}

--- a/http/tracing_test.go
+++ b/http/tracing_test.go
@@ -20,9 +20,23 @@ var _ = Describe("Tracing", func() {
 		srv, err := createServer([]Option{WithTracing("localhost:test", "test")})
 		Expect(err).NotTo(HaveOccurred())
 		ts := httptest.NewServer(srv.Handler)
+		defer ts.Close()
 		_, err = http.Get(ts.URL + "/tracing")
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(len(tracer.FinishedSpans())).To(Equal(1))
+	})
+
+	It("should support websockets", func() {
+		srv, err := createServer([]Option{WithTracing("localhost:test", "test")})
+		Expect(err).NotTo(HaveOccurred())
+		ts := httptest.NewServer(srv.Handler)
+		defer ts.Close()
+
+		err = testWebsocketEcho(ts.URL)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(len(tracer.FinishedSpans())).To(Equal(1))
+
 	})
 })


### PR DESCRIPTION
**What**
- Use the httptest.NewServer were posible
- Use the MockTracer instead of attempting to listen on a UDP port
- Add tests to verify websocket support

**Why**
- this signifficantly improves the consistentcy and speed of the tests

**Notes**
- Three of the websocket tests are failing and I need some help with those

```
Summarizing 3 Failures:

[Fail] Logging [It] should support websockets
/Users/lucasroesler/Code/go/src/github.com/contiamo/goserver/http/logging_test.go:38

[Fail] Metrics [It] should support websockets and tracing
    2 Add test for websocket support
/Users/lucasroesler/Code/go/src/github.com/contiamo/goserver/http/metrics_test.go:36

[Fail] Tracing [It] should support websockets and tracing
/Users/lucasroesler/Code/go/src/github.com/contiamo/goserver/http/tracing_test.go:37
```