### PR TITLE
Feature/websocket enabled tracing and logging mw

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -9,12 +9,6 @@
 
 [[projects]]
   branch = "master"
-  name = "github.com/bakins/logrus-middleware"
-  packages = ["."]
-  revision = "1e20b02c2c9fbae2da8a06168b19cc6fa8f07eef"
-
-[[projects]]
-  branch = "master"
   name = "github.com/bakins/net-http-recover"
   packages = ["."]
   revision = "6cba69d0145946c4f4584974df997378a3297ddc"
@@ -135,12 +129,6 @@
   version = "v1.3.0"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/opentracing-contrib/go-stdlib"
-  packages = ["nethttp"]
-  revision = "36723135187404d2f4002f4f189938565e64cc5c"
-
-[[projects]]
   name = "github.com/opentracing/opentracing-go"
   packages = [
     ".",
@@ -150,12 +138,6 @@
   ]
   revision = "1949ddbfd147afd4d964a9f00b24eb291e0e7c38"
   version = "v1.0.2"
-
-[[projects]]
-  name = "github.com/phayes/freeport"
-  packages = ["."]
-  revision = "b8543db493a5ed890c5499e935e2cad7504f3a04"
-  version = "1.0.2"
 
 [[projects]]
   name = "github.com/pkg/errors"
@@ -239,6 +221,12 @@
   version = "v1.4.0"
 
 [[projects]]
+  name = "github.com/urfave/negroni"
+  packages = ["."]
+  revision = "5dbbc83f748fc3ad38585842b0aedab546d0ea1e"
+  version = "v0.3.0"
+
+[[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
@@ -258,8 +246,7 @@
     "idna",
     "internal/timeseries",
     "lex/httplex",
-    "trace",
-    "websocket"
+    "trace"
   ]
   revision = "d41e8174641f662c5a2d1c7a5f9e828788eb8706"
 
@@ -352,6 +339,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "58a9f66c2462f101e47f6dfb58846868a708de47c09abb06538b914d69af63c6"
+  inputs-digest = "8d2093c8dc8d643cd4468a51cadf936ce4b974389839347d4e33ae1ec3646f22"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/http/cors_test.go
+++ b/http/cors_test.go
@@ -35,7 +35,6 @@ var _ = Describe("CORS", func() {
 		Expect(err).NotTo(HaveOccurred())
 		ts := httptest.NewServer(srv.Handler)
 		defer ts.Close()
-
 		err = testWebsocketEcho(ts.URL)
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/http/metrics.go
+++ b/http/metrics.go
@@ -31,6 +31,8 @@ func (opt *metricsOption) WrapHandler(handler http.Handler) (http.Handler, error
 		},
 		[]string{"code", "method"},
 	)
+	prometheus.Unregister(latency)
+	prometheus.Unregister(requestsCounter)
 	if err := prometheus.Register(latency); err != nil {
 		return nil, err
 	}

--- a/http/tracing.go
+++ b/http/tracing.go
@@ -4,9 +4,12 @@ import (
 	"net/http"
 
 	"github.com/contiamo/goserver"
-	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+	"github.com/urfave/negroni"
 )
+
+// mainly from "github.com/opentracing-contrib/go-stdlib/nethttp"
 
 // WithTracing configures tracing for that server
 func WithTracing(server, app string) Option {
@@ -19,15 +22,102 @@ func (opt *tracingOption) WrapHandler(handler http.Handler) (http.Handler, error
 	if err := goserver.InitTracer(opt.server, opt.app); err != nil {
 		return nil, err
 	}
-	mw := nethttp.Middleware(
+	mw := middleware(
 		opentracing.GlobalTracer(),
 		handler,
-		nethttp.OperationNameFunc(func(r *http.Request) string {
+		operationNameFunc(func(r *http.Request) string {
 			return "HTTP " + r.Method + " " + r.URL.Path
 		}),
-		nethttp.MWSpanObserver(func(sp opentracing.Span, r *http.Request) {
+		mwSpanObserver(func(sp opentracing.Span, r *http.Request) {
 			sp.SetTag("http.uri", r.URL.EscapedPath())
 		}),
+		mwComponentName(opt.app),
 	)
-	return mw, nil
+	n := negroni.New()
+	n.UseHandler(mw)
+	return n, nil
+}
+
+type mwOptions struct {
+	opNameFunc    func(r *http.Request) string
+	spanObserver  func(span opentracing.Span, r *http.Request)
+	componentName string
+}
+
+//mwOption controls the behavior of the Middleware.
+type mwOption func(*mwOptions)
+
+// OperationNameFunc returns a mwOption that uses given function f
+// to generate operation name for each server-side span.
+func operationNameFunc(f func(r *http.Request) string) mwOption {
+	return func(options *mwOptions) {
+		options.opNameFunc = f
+	}
+}
+
+// mwSpanObserver returns a MWOption that observe the span
+// for the server-side span.
+func mwSpanObserver(f func(span opentracing.Span, r *http.Request)) mwOption {
+	return func(options *mwOptions) {
+		options.spanObserver = f
+	}
+}
+
+// MWComponentName returns a mwOption that sets the component name
+// for the server-side span.
+func mwComponentName(componentName string) mwOption {
+	return func(options *mwOptions) {
+		options.componentName = componentName
+	}
+}
+
+// Middleware wraps an http.Handler and traces incoming requests.
+// Additionally, it adds the span to the request's context.
+//
+// By default, the operation name of the spans is set to "HTTP {method}".
+// This can be overriden with options.
+//
+// Example:
+// 	 http.ListenAndServe("localhost:80", nethttp.Middleware(tracer, http.DefaultServeMux))
+//
+// The options allow fine tuning the behavior of the middleware.
+//
+// Example:
+//   mw := nethttp.Middleware(
+//      tracer,
+//      http.DefaultServeMux,
+//      netottp.OperationNameFunc(func(r *http.Request) string {
+//	        return "HTTP " + r.Method + ":/api/customers"
+//      }),
+//      nethttp mwSpanObserver(func(sp opentracing.Span, r *http.Request) {
+//			sp.SetTag("http.uri", r.URL.EscapedPath())
+//		}),
+//   )
+func middleware(tr opentracing.Tracer, h http.Handler, options ...mwOption) http.Handler {
+	opts := mwOptions{
+		opNameFunc: func(r *http.Request) string {
+			return "HTTP " + r.Method
+		},
+		spanObserver: func(span opentracing.Span, r *http.Request) {},
+	}
+
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		ctx, _ := tr.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(r.Header))
+		sp := tr.StartSpan(opts.opNameFunc(r), ext.RPCServerOption(ctx))
+		ext.HTTPMethod.Set(sp, r.Method)
+		ext.HTTPUrl.Set(sp, r.URL.String())
+		opts.spanObserver(sp, r)
+
+		// set component name, use "net/http" if caller does not specify
+		componentName := opts.componentName
+		ext.Component.Set(sp, componentName)
+
+		r = r.WithContext(opentracing.ContextWithSpan(r.Context(), sp))
+
+		h.ServeHTTP(w, r)
+
+		ext.HTTPStatusCode.Set(sp, uint16(w.(negroni.ResponseWriter).Status()))
+		sp.Finish()
+	}
+	return http.HandlerFunc(fn)
 }

--- a/http/tracing_test.go
+++ b/http/tracing_test.go
@@ -32,10 +32,8 @@ var _ = Describe("Tracing", func() {
 		Expect(err).NotTo(HaveOccurred())
 		ts := httptest.NewServer(srv.Handler)
 		defer ts.Close()
-
 		err = testWebsocketEcho(ts.URL)
 		Expect(err).NotTo(HaveOccurred())
-
 		Expect(len(tracer.FinishedSpans())).To(Equal(1))
 
 	})


### PR DESCRIPTION
This mainly forks the libraries used before and make use of the negroni.ResponseWriter to capture the statuscode while preserving the ability to use websockets.