### PR TITLE
Fix opt parsing, clean UUID in path, allow additional tags

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -41,6 +41,12 @@
   revision = "e09c5db296004fbe3f74490e84dcd62c3c5ddb1b"
 
 [[projects]]
+  name = "github.com/google/uuid"
+  packages = ["."]
+  revision = "064e2069ce9c359c118179501254f67d7d37ba24"
+  version = "0.2"
+
+[[projects]]
   name = "github.com/gorilla/websocket"
   packages = ["."]
   revision = "ea4d1f681babbce9545c9c5f3d5194a789c89f5b"
@@ -339,6 +345,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8d2093c8dc8d643cd4468a51cadf936ce4b974389839347d4e33ae1ec3646f22"
+  inputs-digest = "d375127ccb0621d8c3bd930edc5cb38da8f0ce94d6880ad67109ef99c0ca16ee"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/example/main.go
+++ b/example/main.go
@@ -44,7 +44,7 @@ func main() {
 		}),
 		Options: []httpserver.Option{
 			httpserver.WithLogging("http-echo"),
-			httpserver.WithTracing("localhost:6831", "example", map[string]string{"example.namespace": "test"}),
+			httpserver.WithTracing("localhost:6831", "example", map[string]string{"example.namespace": "test"}, nil),
 			httpserver.WithMetrics("http-echo"),
 			httpserver.WithRecovery(os.Stderr, true),
 		},

--- a/example/main.go
+++ b/example/main.go
@@ -44,7 +44,7 @@ func main() {
 		}),
 		Options: []httpserver.Option{
 			httpserver.WithLogging("http-echo"),
-			httpserver.WithTracing("localhost:6831", "example"),
+			httpserver.WithTracing("localhost:6831", "example", map[string]string{"example.namespace": "test"}),
 			httpserver.WithMetrics("http-echo"),
 			httpserver.WithRecovery(os.Stderr, true),
 		},

--- a/http/tracing.go
+++ b/http/tracing.go
@@ -2,8 +2,10 @@ package server
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/contiamo/goserver"
+	uuid "github.com/google/uuid"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/urfave/negroni"
@@ -12,11 +14,14 @@ import (
 // mainly from "github.com/opentracing-contrib/go-stdlib/nethttp"
 
 // WithTracing configures tracing for that server
-func WithTracing(server, app string) Option {
-	return &tracingOption{server, app}
+func WithTracing(server, app string, tags map[string]string) Option {
+	return &tracingOption{server, app, tags}
 }
 
-type tracingOption struct{ server, app string }
+type tracingOption struct {
+	server, app string
+	tags        map[string]string
+}
 
 func (opt *tracingOption) WrapHandler(handler http.Handler) (http.Handler, error) {
 	if err := goserver.InitTracer(opt.server, opt.app); err != nil {
@@ -25,11 +30,12 @@ func (opt *tracingOption) WrapHandler(handler http.Handler) (http.Handler, error
 	mw := middleware(
 		opentracing.GlobalTracer(),
 		handler,
-		operationNameFunc(func(r *http.Request) string {
-			return "HTTP " + r.Method + " " + r.URL.Path
-		}),
+		operationNameFunc(methodAndPathCleanUUID),
 		mwSpanObserver(func(sp opentracing.Span, r *http.Request) {
 			sp.SetTag("http.uri", r.URL.EscapedPath())
+			for k, v := range opt.tags {
+				sp.SetTag(k, v)
+			}
 		}),
 		mwComponentName(opt.app),
 	)
@@ -53,6 +59,17 @@ func operationNameFunc(f func(r *http.Request) string) mwOption {
 	return func(options *mwOptions) {
 		options.opNameFunc = f
 	}
+}
+
+func methodAndPathCleanUUID(r *http.Request) string {
+	pathParts := strings.Split(r.URL.Path, "/")
+	for i, part := range pathParts {
+		_, err := uuid.Parse(part)
+		if err == nil {
+			pathParts[i] = "*"
+		}
+	}
+	return "HTTP " + r.Method + " " + strings.Join(pathParts, "/")
 }
 
 // mwSpanObserver returns a MWOption that observe the span
@@ -99,6 +116,10 @@ func middleware(tr opentracing.Tracer, h http.Handler, options ...mwOption) http
 			return "HTTP " + r.Method
 		},
 		spanObserver: func(span opentracing.Span, r *http.Request) {},
+	}
+
+	for _, opt := range options {
+		opt(&opts)
 	}
 
 	fn := func(w http.ResponseWriter, r *http.Request) {

--- a/http/tracing.go
+++ b/http/tracing.go
@@ -17,7 +17,7 @@ import (
 // WithTracing configures tracing for that server
 func WithTracing(server, app string, tags map[string]string, opNameFunc func(r *http.Request) string) Option {
 	if opNameFunc == nil {
-		opNameFunc = methodAndPathCleanID
+		opNameFunc = MethodAndPathCleanID
 	}
 	return &tracingOption{server, app, tags, opNameFunc}
 }
@@ -66,9 +66,9 @@ func operationNameFunc(f func(r *http.Request) string) mwOption {
 	}
 }
 
-// methodAndPathCleanID replace string values that look like ids (uuids and int)
+// MethodAndPathCleanID replace string values that look like ids (uuids and int)
 // with "*"
-func methodAndPathCleanID(r *http.Request) string {
+func MethodAndPathCleanID(r *http.Request) string {
 	pathParts := strings.Split(r.URL.Path, "/")
 	for i, part := range pathParts {
 		if _, err := uuid.Parse(part); err == nil {

--- a/http/tracing_test.go
+++ b/http/tracing_test.go
@@ -17,24 +17,54 @@ var _ = Describe("Tracing", func() {
 	opentracing.SetGlobalTracer(tracer)
 
 	It("should be possible to setup tracing", func() {
-		srv, err := createServer([]Option{WithTracing("localhost:test", "test")})
+		srv, err := createServer([]Option{WithTracing("localhost:test", "test", nil)})
 		Expect(err).NotTo(HaveOccurred())
 		ts := httptest.NewServer(srv.Handler)
 		defer ts.Close()
-		_, err = http.Get(ts.URL + "/tracing")
+		_, err = http.Get(ts.URL + "/tracing/")
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(len(tracer.FinishedSpans())).To(Equal(1))
+		tracer.Reset()
 	})
 
-	It("should support websockets", func() {
-		srv, err := createServer([]Option{WithTracing("localhost:test", "test")})
+	It("should be possible to set additional tags", func() {
+		tagName := "testTag"
+		tagValue := "something to find"
+		srv, err := createServer([]Option{WithTracing("localhost:test", "test", map[string]string{tagName: tagValue})})
+		Expect(err).NotTo(HaveOccurred())
+		ts := httptest.NewServer(srv.Handler)
+		defer ts.Close()
+		_, err = http.Get(ts.URL + "/tracing/")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(len(tracer.FinishedSpans())).To(Equal(1))
+
+		span := tracer.FinishedSpans()[0]
+		Expect(span.Tags()[tagName]).To(Equal(tagValue))
+		tracer.Reset()
+	})
+
+	It("should replace uuid values with *", func() {
+		srv, err := createServer([]Option{WithTracing("localhost:test", "test", nil)})
+		Expect(err).NotTo(HaveOccurred())
+		ts := httptest.NewServer(srv.Handler)
+		defer ts.Close()
+		_, err = http.Get(ts.URL + "/tracing/2f6f97f2-5f44-476d-bc0c-180b2eaa36ca/2f6f97f2-5f44-476d-bc0c-180b2eaa36cb")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(len(tracer.FinishedSpans())).To(Equal(1))
+		span := tracer.FinishedSpans()[0]
+		Expect(span.OperationName).To(Equal("HTTP GET /tracing/*/*"))
+		tracer.Reset()
+	})
+
+	It("should allow websockets", func() {
+		srv, err := createServer([]Option{WithTracing("localhost:test", "test", nil)})
 		Expect(err).NotTo(HaveOccurred())
 		ts := httptest.NewServer(srv.Handler)
 		defer ts.Close()
 		err = testWebsocketEcho(ts.URL)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(len(tracer.FinishedSpans())).To(Equal(1))
-
 	})
 })

--- a/http/tracing_test.go
+++ b/http/tracing_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Tracing", func() {
 	opentracing.SetGlobalTracer(tracer)
 
 	It("should be possible to setup tracing", func() {
-		srv, err := createServer([]Option{WithTracing("localhost:test", "test", nil)})
+		srv, err := createServer([]Option{WithTracing("localhost:test", "test", nil, nil)})
 		Expect(err).NotTo(HaveOccurred())
 		ts := httptest.NewServer(srv.Handler)
 		defer ts.Close()
@@ -31,7 +31,7 @@ var _ = Describe("Tracing", func() {
 	It("should be possible to set additional tags", func() {
 		tagName := "testTag"
 		tagValue := "something to find"
-		srv, err := createServer([]Option{WithTracing("localhost:test", "test", map[string]string{tagName: tagValue})})
+		srv, err := createServer([]Option{WithTracing("localhost:test", "test", map[string]string{tagName: tagValue}, nil)})
 		Expect(err).NotTo(HaveOccurred())
 		ts := httptest.NewServer(srv.Handler)
 		defer ts.Close()
@@ -46,7 +46,7 @@ var _ = Describe("Tracing", func() {
 	})
 
 	It("should replace uuid values with *", func() {
-		srv, err := createServer([]Option{WithTracing("localhost:test", "test", nil)})
+		srv, err := createServer([]Option{WithTracing("localhost:test", "test", nil, nil)})
 		Expect(err).NotTo(HaveOccurred())
 		ts := httptest.NewServer(srv.Handler)
 		defer ts.Close()
@@ -60,7 +60,7 @@ var _ = Describe("Tracing", func() {
 	})
 
 	It("should allow websockets", func() {
-		srv, err := createServer([]Option{WithTracing("localhost:test", "test", nil)})
+		srv, err := createServer([]Option{WithTracing("localhost:test", "test", nil, nil)})
 		Expect(err).NotTo(HaveOccurred())
 		ts := httptest.NewServer(srv.Handler)
 		defer ts.Close()


### PR DESCRIPTION
**What**
- Fix option parsing for the tracing middleware
- Set the default operation name function to scrub UUID values from the
url path
- Allow passing additional fixed set of tags to the spans

**Why**
- This creates operation names that are easier to read and aggregate
- The additional tags allow us to pass additional serverwide values as
tags to the routing spans, e.g. tenantid or application version

**Notes**
- I didn't update the grpc middleware because I wasn't sure exactly how it was working, it didn't seem to have any real customization going on.  It would be nice to update this with the extra tags option that was added for the http server

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>