### PR TITLE
Add new grpc middleware for debugging metadata

### DIFF
--- a/grpc/metadatalogging.go
+++ b/grpc/metadatalogging.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"context"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// WithMDLogging configures a logrus logger to log all gRPC requests with duration and return status
+func WithMDLogging() Option {
+	return &mdLoggingOption{}
+}
+
+type mdLoggingOption struct{}
+
+func (opt *mdLoggingOption) GetOptions() (grpc.ServerOption, grpc.StreamServerInterceptor, grpc.UnaryServerInterceptor, error) {
+	si := StreamServerInterceptor()
+	ui := UnaryServerInterceptor()
+	return nil, si, ui, nil
+}
+
+func (opt *mdLoggingOption) PostProcess(s *grpc.Server) error {
+	return nil
+}
+
+// UnaryServerInterceptor returns a new unary server interceptors that adds logrus.Entry to the context.
+func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		fields := extractLoggingFields(ctx)
+		logrus.WithFields(fields).Debug("processed request")
+		return handler(ctx, req)
+	}
+}
+
+// StreamServerInterceptor returns a new streaming server interceptor that adds logrus.Entry to the context.
+func StreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		fields := extractLoggingFields(stream.Context())
+		logrus.WithFields(fields).Debug("processed stream")
+		return handler(srv, stream)
+	}
+}
+
+func extractLoggingFields(ctx context.Context) logrus.Fields {
+	fields := logrus.Fields{}
+
+	if ctxMd, ok := metadata.FromIncomingContext(ctx); ok {
+		for field, values := range ctxMd {
+			fields[field] = strings.Join(values, ",")
+		}
+	}
+	return fields
+}

--- a/grpc/metadatalogging_test.go
+++ b/grpc/metadatalogging_test.go
@@ -1,0 +1,40 @@
+package server_test
+
+import (
+	"bytes"
+	"context"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/contiamo/goserver/grpc"
+	"github.com/contiamo/goserver/grpc/test"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/metadata"
+)
+
+var _ = Describe("Logging", func() {
+	It("should be possible to setup logging option", func() {
+		buf := &bytes.Buffer{}
+		logrus.SetOutput(buf)
+		logrus.SetLevel(logrus.DebugLevel)
+		srv, err := createServerWithOptions([]Option{WithMDLogging()})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(srv).NotTo(BeNil())
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go ListenAndServe(ctx, ":3003", srv)
+		cli, err := createPlaintextTestClient(ctx, "localhost:3003")
+		Expect(err).NotTo(HaveOccurred())
+
+		md := metadata.New(map[string]string{"test": "value"})
+		ctx = metadata.NewOutgoingContext(ctx, md)
+
+		resp, err := cli.Ping(ctx, &test.PingReq{Msg: "test"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.Msg).To(Equal("test"))
+		Expect(strings.Contains(buf.String(), "finished unary call with code OK")).To(BeTrue())
+		Expect(strings.Contains(buf.String(), "test:\"value\"")).To(BeTrue())
+	})
+})


### PR DESCRIPTION
**What**
- Add new WithMDLogging that creates a grpc middleware for logging the
metadata attached to a request or a stream

Signed-off-by: Lucas Roesler <roesler.lucas@gmail.com>