### PR TITLE
Add stack trace logging to the grpc-recovery middleware

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -76,7 +76,7 @@
   branch = "master"
   name = "github.com/grpc-ecosystem/grpc-opentracing"
   packages = ["go/otgrpc"]
-  revision = "0e7658f8ee99ee5aa683e2a032b8880091b7a055"
+  revision = "8e809c8a86450a29b90dcc9efbf062d0fe6d9746"
 
 [[projects]]
   name = "github.com/improbable-eng/grpc-web"
@@ -345,6 +345,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d375127ccb0621d8c3bd930edc5cb38da8f0ce94d6880ad67109ef99c0ca16ee"
+  inputs-digest = "df47e7edbf999da0be564db9909cf3860b7d98445004312b31b89271d531ea4b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/grpc/credentials.go
+++ b/grpc/credentials.go
@@ -1,4 +1,4 @@
-package server
+package grpc
 
 import (
 	"crypto/tls"

--- a/grpc/credentials_test.go
+++ b/grpc/credentials_test.go
@@ -1,4 +1,4 @@
-package server_test
+package grpc
 
 import (
 	"context"
@@ -6,7 +6,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/contiamo/goserver/grpc"
 	"github.com/contiamo/goserver/grpc/test"
 )
 

--- a/grpc/credentials_test.go
+++ b/grpc/credentials_test.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -19,7 +20,11 @@ var _ = Describe("Credentials", func() {
 		Expect(srv).NotTo(BeNil())
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		go ListenAndServe(ctx, ":3001", srv)
+		// it takes some time to run the server, can't be accessed immediately
+		time.Sleep(100 * time.Millisecond)
+
 		cli, err := createTestClient(ctx, "localhost:3001")
 		Expect(err).NotTo(HaveOccurred())
 		resp, err := cli.Ping(ctx, &test.PingReq{Msg: "test"})
@@ -36,7 +41,11 @@ var _ = Describe("Credentials", func() {
 		Expect(srv).NotTo(BeNil())
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		go ListenAndServe(ctx, ":3002", srv)
+		// it takes some time to run the server, can't be accessed immediately
+		time.Sleep(100 * time.Millisecond)
+
 		cli, err := createTestClient(ctx, "localhost:3002")
 		Expect(err).NotTo(HaveOccurred())
 		resp, err := cli.Ping(ctx, &test.PingReq{Msg: "test"})

--- a/grpc/grpc_suite_test.go
+++ b/grpc/grpc_suite_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/contiamo/goserver/grpc/test"
+	utils "github.com/contiamo/goserver/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
@@ -14,6 +15,8 @@ import (
 
 func TestGrpc(t *testing.T) {
 	RegisterFailHandler(Fail)
+	restore := utils.DiscardLogging()
+	defer restore()
 	RunSpecs(t, "Grpc Suite")
 }
 

--- a/grpc/grpc_suite_test.go
+++ b/grpc/grpc_suite_test.go
@@ -1,11 +1,10 @@
-package server_test
+package grpc
 
 import (
 	"context"
 	"crypto/tls"
 	"testing"
 
-	. "github.com/contiamo/goserver/grpc"
 	"github.com/contiamo/goserver/grpc/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/grpc/logging.go
+++ b/grpc/logging.go
@@ -1,4 +1,4 @@
-package server
+package grpc
 
 import (
 	"time"

--- a/grpc/logging_test.go
+++ b/grpc/logging_test.go
@@ -1,31 +1,32 @@
 package grpc
 
 import (
-	"bytes"
 	"context"
-	"os"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"github.com/contiamo/goserver/grpc/test"
-	"github.com/sirupsen/logrus"
+	utils "github.com/contiamo/goserver/test"
 )
 
 var _ = Describe("Logging", func() {
 	It("should be possible to setup logging option", func() {
-		buf := &bytes.Buffer{}
-		logrus.SetOutput(buf)
-		defer func() {
-			logrus.SetOutput(os.Stdout)
-		}()
+		buf, restore := utils.SetupLoggingBuffer()
+		defer restore()
+
 		srv, err := createServerWithOptions([]Option{WithLogging("test")})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(srv).NotTo(BeNil())
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		go ListenAndServe(ctx, ":3003", srv)
+		// it takes some time to run the server, can't be accessed immediately
+		time.Sleep(100 * time.Millisecond)
+
 		cli, err := createPlaintextTestClient(ctx, "localhost:3003")
 		Expect(err).NotTo(HaveOccurred())
 		resp, err := cli.Ping(ctx, &test.PingReq{Msg: "test"})

--- a/grpc/logging_test.go
+++ b/grpc/logging_test.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"bytes"
 	"context"
+	"os"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
@@ -16,6 +17,9 @@ var _ = Describe("Logging", func() {
 	It("should be possible to setup logging option", func() {
 		buf := &bytes.Buffer{}
 		logrus.SetOutput(buf)
+		defer func() {
+			logrus.SetOutput(os.Stdout)
+		}()
 		srv, err := createServerWithOptions([]Option{WithLogging("test")})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(srv).NotTo(BeNil())

--- a/grpc/logging_test.go
+++ b/grpc/logging_test.go
@@ -1,4 +1,4 @@
-package server_test
+package grpc
 
 import (
 	"bytes"
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/contiamo/goserver/grpc"
 	"github.com/contiamo/goserver/grpc/test"
 	"github.com/sirupsen/logrus"
 )

--- a/grpc/metadatalogging.go
+++ b/grpc/metadatalogging.go
@@ -1,4 +1,4 @@
-package server
+package grpc
 
 import (
 	"context"

--- a/grpc/metadatalogging_test.go
+++ b/grpc/metadatalogging_test.go
@@ -5,12 +5,13 @@ import (
 	"context"
 	"strings"
 
+	"google.golang.org/grpc/metadata"
+
+	"github.com/contiamo/goserver/grpc/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/contiamo/goserver/grpc/test"
 	"github.com/sirupsen/logrus"
-	"google.golang.org/grpc/metadata"
 )
 
 var _ = Describe("Logging", func() {
@@ -23,8 +24,9 @@ var _ = Describe("Logging", func() {
 		Expect(srv).NotTo(BeNil())
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		go ListenAndServe(ctx, ":3003", srv)
-		cli, err := createPlaintextTestClient(ctx, "localhost:3003")
+		cli, err := createPlaintextTestClient(ctx, ":3003")
 		Expect(err).NotTo(HaveOccurred())
 
 		md := metadata.New(map[string]string{"test": "value"})
@@ -33,7 +35,8 @@ var _ = Describe("Logging", func() {
 		resp, err := cli.Ping(ctx, &test.PingReq{Msg: "test"})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resp.Msg).To(Equal("test"))
-		Expect(strings.Contains(buf.String(), "finished unary call with code OK")).To(BeTrue())
-		Expect(strings.Contains(buf.String(), "test:\"value\"")).To(BeTrue())
+
+		Expect(strings.Contains(buf.String(), "finished unary call with code OK")).To(BeTrue(), "This should be an expected OK message in logs but got %s", buf.String())
+		Expect(strings.Contains(buf.String(), "test:\"value\"")).To(BeTrue(), "This should be the value in logs but got %s", buf.String())
 	})
 })

--- a/grpc/metadatalogging_test.go
+++ b/grpc/metadatalogging_test.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"bytes"
 	"context"
+	"os"
 	"strings"
 
 	"google.golang.org/grpc/metadata"
@@ -17,8 +18,13 @@ import (
 var _ = Describe("Logging", func() {
 	It("should be possible to setup logging option", func() {
 		buf := &bytes.Buffer{}
+		level := logrus.GetLevel()
 		logrus.SetOutput(buf)
 		logrus.SetLevel(logrus.DebugLevel)
+		defer func() {
+			logrus.SetOutput(os.Stdout)
+			logrus.SetLevel(level)
+		}()
 		srv, err := createServerWithOptions([]Option{WithMDLogging()})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(srv).NotTo(BeNil())

--- a/grpc/metadatalogging_test.go
+++ b/grpc/metadatalogging_test.go
@@ -1,4 +1,4 @@
-package server_test
+package grpc
 
 import (
 	"bytes"
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/contiamo/goserver/grpc"
 	"github.com/contiamo/goserver/grpc/test"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/metadata"

--- a/grpc/metrics.go
+++ b/grpc/metrics.go
@@ -1,4 +1,4 @@
-package server
+package grpc
 
 import (
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"

--- a/grpc/metrics_test.go
+++ b/grpc/metrics_test.go
@@ -1,4 +1,4 @@
-package server_test
+package grpc
 
 import (
 	"context"
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/contiamo/goserver"
-	. "github.com/contiamo/goserver/grpc"
 	"github.com/contiamo/goserver/grpc/test"
 )
 

--- a/grpc/metrics_test.go
+++ b/grpc/metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -20,8 +21,12 @@ var _ = Describe("Metrics", func() {
 		Expect(srv).NotTo(BeNil())
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		go ListenAndServe(ctx, ":3004", srv)
 		go goserver.ListenAndServeMetricsAndHealth(":8080", nil)
+		// it takes some time to run the servers, can't be accessed immediately
+		time.Sleep(100 * time.Millisecond)
+
 		cli, err := createPlaintextTestClient(ctx, "localhost:3004")
 		Expect(err).NotTo(HaveOccurred())
 		_, err = cli.Ping(ctx, &test.PingReq{Msg: "test"})

--- a/grpc/recovery.go
+++ b/grpc/recovery.go
@@ -1,4 +1,4 @@
-package server
+package grpc
 
 import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/recovery"

--- a/grpc/recovery.go
+++ b/grpc/recovery.go
@@ -1,8 +1,12 @@
 package grpc
 
 import (
+	"runtime/debug"
+
 	"github.com/grpc-ecosystem/go-grpc-middleware/recovery"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 )
 
 // WithRecovery recovers the server from panics caused inside of the gRPC calls
@@ -13,8 +17,17 @@ func WithRecovery() Option {
 type recoveryOption struct{}
 
 func (opt *recoveryOption) GetOptions() (grpc.ServerOption, grpc.StreamServerInterceptor, grpc.UnaryServerInterceptor, error) {
-	si := grpc_recovery.StreamServerInterceptor()
-	ui := grpc_recovery.UnaryServerInterceptor()
+	recOpt := grpc_recovery.WithRecoveryHandler(func(p interface{}) (err error) {
+		switch err := p.(type) {
+		case error:
+			logrus.WithFields(logrus.Fields{
+				"stacktrace": string(debug.Stack()),
+			}).Error(err)
+		}
+		return grpc.Errorf(codes.Internal, "%s", p)
+	})
+	si := grpc_recovery.StreamServerInterceptor(recOpt)
+	ui := grpc_recovery.UnaryServerInterceptor(recOpt)
 	return nil, si, ui, nil
 }
 

--- a/grpc/recovery_test.go
+++ b/grpc/recovery_test.go
@@ -1,28 +1,23 @@
 package grpc
 
 import (
-	"bytes"
 	"context"
-	"os"
 	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
 	"github.com/contiamo/goserver/grpc/test"
+	utils "github.com/contiamo/goserver/test"
 )
 
 var _ = Describe("Recovery", func() {
 	It("should recover from panic when recovery option is set", func() {
-		buf := &bytes.Buffer{}
-		logrus.SetOutput(buf)
-		defer func() {
-			logrus.SetOutput(os.Stdout)
-		}()
+		buf, restore := utils.SetupLoggingBuffer()
+		defer restore()
 
 		srv, err := createServerWithOptions([]Option{WithRecovery()})
 		Expect(err).NotTo(HaveOccurred())
@@ -30,7 +25,8 @@ var _ = Describe("Recovery", func() {
 		defer cancel()
 
 		go ListenAndServe(ctx, ":3005", srv)
-		time.Sleep(time.Second)
+		// it takes some time to run the server, can't be accessed immediately
+		time.Sleep(100 * time.Millisecond)
 
 		cli, err := createPlaintextTestClient(ctx, "localhost:3005")
 		Expect(err).NotTo(HaveOccurred())

--- a/grpc/recovery_test.go
+++ b/grpc/recovery_test.go
@@ -1,4 +1,4 @@
-package server_test
+package grpc
 
 import (
 	"context"
@@ -8,7 +8,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
-	. "github.com/contiamo/goserver/grpc"
 	"github.com/contiamo/goserver/grpc/test"
 )
 

--- a/grpc/recovery_test.go
+++ b/grpc/recovery_test.go
@@ -2,9 +2,12 @@ package grpc
 
 import (
 	"context"
+	"io/ioutil"
+	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
@@ -13,6 +16,10 @@ import (
 
 var _ = Describe("Recovery", func() {
 	It("should recover from panic when recovery option is set", func() {
+		logrus.SetOutput(ioutil.Discard)
+		defer func() {
+			logrus.SetOutput(os.Stdout)
+		}()
 		srv, err := createServerWithOptions([]Option{WithRecovery()})
 		Expect(err).NotTo(HaveOccurred())
 		ctx, cancel := context.WithCancel(context.Background())

--- a/grpc/recovery_test.go
+++ b/grpc/recovery_test.go
@@ -1,9 +1,11 @@
 package grpc
 
 import (
+	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
+	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -16,19 +18,26 @@ import (
 
 var _ = Describe("Recovery", func() {
 	It("should recover from panic when recovery option is set", func() {
-		logrus.SetOutput(ioutil.Discard)
+		buf := &bytes.Buffer{}
+		logrus.SetOutput(buf)
 		defer func() {
 			logrus.SetOutput(os.Stdout)
 		}()
+
 		srv, err := createServerWithOptions([]Option{WithRecovery()})
 		Expect(err).NotTo(HaveOccurred())
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		go ListenAndServe(ctx, ":3005", srv)
+		time.Sleep(time.Second)
+
 		cli, err := createPlaintextTestClient(ctx, "localhost:3005")
 		Expect(err).NotTo(HaveOccurred())
-		_, err = cli.Panic(ctx, &test.PingReq{})
+		_, err = cli.Panic(ctx, &test.PingReq{"Very bad panic"})
+
 		Expect(err).To(HaveOccurred())
 		Expect(grpc.Code(err)).To(Equal(codes.Internal))
+		Expect(strings.Contains(buf.String(), `level=error msg="Very bad panic" stacktrace=`)).To(BeTrue(), "The logs should contain the error message and stacktrace but got %s", buf.String())
 	})
 })

--- a/grpc/reflection.go
+++ b/grpc/reflection.go
@@ -1,4 +1,4 @@
-package server
+package grpc
 
 import (
 	"google.golang.org/grpc"

--- a/grpc/reflection_test.go
+++ b/grpc/reflection_test.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"context"
 	"os/exec"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -14,7 +15,11 @@ var _ = Describe("Reflection", func() {
 		Expect(err).NotTo(HaveOccurred())
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		go ListenAndServe(ctx, ":3006", srv)
+		// it takes some time to run the server, can't be accessed immediately
+		time.Sleep(100 * time.Millisecond)
+
 		cmd := exec.Command("grpcurl", "-plaintext", "localhost:3006", "describe")
 		Expect(cmd.Run()).To(Succeed())
 	})

--- a/grpc/reflection_test.go
+++ b/grpc/reflection_test.go
@@ -1,4 +1,4 @@
-package server_test
+package grpc
 
 import (
 	"context"
@@ -6,8 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	. "github.com/contiamo/goserver/grpc"
 )
 
 var _ = Describe("Reflection", func() {

--- a/grpc/server.go
+++ b/grpc/server.go
@@ -1,4 +1,4 @@
-package server
+package grpc
 
 import (
 	"context"

--- a/grpc/test/pingpong.go
+++ b/grpc/test/pingpong.go
@@ -1,6 +1,9 @@
 package test
 
-import "context"
+import (
+	"context"
+	"errors"
+)
 
 func NewPingPongServer() PingPongServer {
 	return &pingPongServer{}
@@ -12,6 +15,6 @@ func (srv *pingPongServer) Ping(ctx context.Context, req *PingReq) (*PingResp, e
 	return &PingResp{Msg: req.Msg}, nil
 }
 func (srv *pingPongServer) Panic(ctx context.Context, req *PingReq) (*PingResp, error) {
-	panic(req)
+	panic(errors.New(req.Msg))
 	return &PingResp{Msg: req.Msg}, nil
 }

--- a/grpc/tracing.go
+++ b/grpc/tracing.go
@@ -1,4 +1,4 @@
-package server
+package grpc
 
 import (
 	"github.com/contiamo/goserver"

--- a/grpc/tracing_test.go
+++ b/grpc/tracing_test.go
@@ -1,4 +1,4 @@
-package server_test
+package grpc
 
 import (
 	"context"
@@ -8,7 +8,6 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/mocktracer"
 
-	. "github.com/contiamo/goserver/grpc"
 	"github.com/contiamo/goserver/grpc/test"
 )
 

--- a/grpc/tracing_test.go
+++ b/grpc/tracing_test.go
@@ -2,6 +2,7 @@ package grpc
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -23,6 +24,9 @@ var _ = Describe("Tracing", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		go ListenAndServe(ctx, ":1234", srv)
+		// it takes some time to run the server, can't be accessed immediately
+		time.Sleep(100 * time.Millisecond)
+
 		cli, err := createPlaintextTestClient(ctx, "localhost:1234")
 		Expect(err).NotTo(HaveOccurred())
 		_, err = cli.Ping(ctx, &test.PingReq{})

--- a/http/cors.go
+++ b/http/cors.go
@@ -1,4 +1,4 @@
-package server
+package http
 
 import (
 	"net/http"

--- a/http/cors_test.go
+++ b/http/cors_test.go
@@ -1,4 +1,4 @@
-package server_test
+package http
 
 import (
 	"net/http"
@@ -6,8 +6,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	. "github.com/contiamo/goserver/http"
 )
 
 var _ = Describe("CORS", func() {

--- a/http/grpcweb.go
+++ b/http/grpcweb.go
@@ -1,4 +1,4 @@
-package server
+package http
 
 import (
 	"net/http"

--- a/http/grpcweb_test.go
+++ b/http/grpcweb_test.go
@@ -1,4 +1,4 @@
-package server_test
+package http
 
 import (
 	"context"
@@ -9,7 +9,6 @@ import (
 
 	grpcserver "github.com/contiamo/goserver/grpc"
 	"github.com/contiamo/goserver/grpc/test"
-	. "github.com/contiamo/goserver/http"
 )
 
 var _ = Describe("Grpcweb", func() {

--- a/http/http_suite_test.go
+++ b/http/http_suite_test.go
@@ -9,12 +9,15 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	utils "github.com/contiamo/goserver/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 func TestHttp(t *testing.T) {
 	RegisterFailHandler(Fail)
+	restore := utils.DiscardLogging()
+	defer restore()
 	RunSpecs(t, "Http Suite")
 }
 

--- a/http/http_suite_test.go
+++ b/http/http_suite_test.go
@@ -1,4 +1,4 @@
-package server_test
+package http
 
 import (
 	"fmt"
@@ -9,7 +9,6 @@ import (
 
 	"github.com/gorilla/websocket"
 
-	httpserver "github.com/contiamo/goserver/http"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -39,7 +38,7 @@ func echoWS(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func createServer(opts []httpserver.Option) (*http.Server, error) {
+func createServer(opts []Option) (*http.Server, error) {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/ws/", echoWS)
@@ -50,7 +49,7 @@ func createServer(opts []httpserver.Option) (*http.Server, error) {
 		io.Copy(w, r.Body)
 	})
 
-	return httpserver.New(&httpserver.Config{
+	return New(&Config{
 		Handler: mux,
 		Options: opts,
 	})

--- a/http/logging.go
+++ b/http/logging.go
@@ -1,4 +1,4 @@
-package server
+package http
 
 import (
 	"net/http"

--- a/http/logging_test.go
+++ b/http/logging_test.go
@@ -1,26 +1,22 @@
 package http
 
 import (
-	"bytes"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"time"
 
+	utils "github.com/contiamo/goserver/test"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("Logging", func() {
 
 	It("should be possible to configure logging", func() {
-		buf := &bytes.Buffer{}
-		logrus.SetOutput(buf)
-		defer func() {
-			logrus.SetOutput(os.Stdout)
-		}()
+		buf, restore := utils.SetupLoggingBuffer()
+		defer restore()
+
 		srv, err := createServer([]Option{WithLogging("test")})
 		Expect(err).NotTo(HaveOccurred())
 		ts := httptest.NewServer(srv.Handler)
@@ -31,11 +27,9 @@ var _ = Describe("Logging", func() {
 	})
 
 	It("should support websockets", func() {
-		buf := &Buffer{}
-		logrus.SetOutput(buf)
-		defer func() {
-			logrus.SetOutput(os.Stdout)
-		}()
+		buf, restore := utils.SetupLoggingBuffer()
+		defer restore()
+
 		srv, err := createServer([]Option{WithLogging("test")})
 		Expect(err).NotTo(HaveOccurred())
 		ts := httptest.NewServer(srv.Handler)
@@ -46,16 +40,3 @@ var _ = Describe("Logging", func() {
 		Expect(strings.Contains(buf.String(), "successfully handled request")).To(BeTrue())
 	})
 })
-
-type Buffer struct {
-	data []byte
-}
-
-func (b *Buffer) Write(data []byte) (int, error) {
-	b.data = append(b.data, data...)
-	return len(data), nil
-}
-
-func (b *Buffer) String() string {
-	return string(b.data)
-}

--- a/http/logging_test.go
+++ b/http/logging_test.go
@@ -1,4 +1,4 @@
-package server_test
+package http
 
 import (
 	"bytes"
@@ -10,8 +10,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-
-	. "github.com/contiamo/goserver/http"
 )
 
 var _ = Describe("Logging", func() {

--- a/http/logging_test.go
+++ b/http/logging_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"time"
 
@@ -17,6 +18,9 @@ var _ = Describe("Logging", func() {
 	It("should be possible to configure logging", func() {
 		buf := &bytes.Buffer{}
 		logrus.SetOutput(buf)
+		defer func() {
+			logrus.SetOutput(os.Stdout)
+		}()
 		srv, err := createServer([]Option{WithLogging("test")})
 		Expect(err).NotTo(HaveOccurred())
 		ts := httptest.NewServer(srv.Handler)
@@ -29,6 +33,9 @@ var _ = Describe("Logging", func() {
 	It("should support websockets", func() {
 		buf := &Buffer{}
 		logrus.SetOutput(buf)
+		defer func() {
+			logrus.SetOutput(os.Stdout)
+		}()
 		srv, err := createServer([]Option{WithLogging("test")})
 		Expect(err).NotTo(HaveOccurred())
 		ts := httptest.NewServer(srv.Handler)

--- a/http/metrics.go
+++ b/http/metrics.go
@@ -1,4 +1,4 @@
-package server
+package http
 
 import (
 	"net/http"

--- a/http/metrics_test.go
+++ b/http/metrics_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -19,10 +20,18 @@ var _ = Describe("Metrics", func() {
 		Expect(err).NotTo(HaveOccurred())
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
 		go ListenAndServe(ctx, ":4002", srv)
+		// it takes some time to run the server, can't be accessed immediately
+		time.Sleep(100 * time.Millisecond)
+
 		_, err = http.Get("http://localhost:4002/metrics_test")
 		Expect(err).NotTo(HaveOccurred())
+
 		go goserver.ListenAndServeMetricsAndHealth(":8080", nil)
+		// it takes some time to run the server, can't be accessed immediately
+		time.Sleep(100 * time.Millisecond)
+
 		resp, err := http.Get("http://localhost:8080/metrics")
 		Expect(err).NotTo(HaveOccurred())
 		defer resp.Body.Close()
@@ -40,6 +49,9 @@ var _ = Describe("Metrics", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		go goserver.ListenAndServeMetricsAndHealth(":8080", nil)
+		// it takes some time to run the server, can't be accessed immediately
+		time.Sleep(100 * time.Millisecond)
+
 		resp, err := http.Get("http://localhost:8080/metrics")
 		Expect(err).NotTo(HaveOccurred())
 		defer resp.Body.Close()

--- a/http/metrics_test.go
+++ b/http/metrics_test.go
@@ -1,4 +1,4 @@
-package server_test
+package http
 
 import (
 	"context"
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/contiamo/goserver"
-	. "github.com/contiamo/goserver/http"
 )
 
 var _ = Describe("Metrics", func() {

--- a/http/recovery.go
+++ b/http/recovery.go
@@ -1,4 +1,4 @@
-package server
+package http
 
 import (
 	"io"

--- a/http/recovery_test.go
+++ b/http/recovery_test.go
@@ -4,20 +4,13 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 )
 
 var _ = Describe("Recovery", func() {
 	It("should be possible to configure panic recovery", func() {
-		logrus.SetOutput(ioutil.Discard)
-		defer func() {
-			logrus.SetOutput(os.Stdout)
-		}()
-
 		srv, err := createServer([]Option{WithRecovery(ioutil.Discard, true)})
 		Expect(err).NotTo(HaveOccurred())
 		ts := httptest.NewServer(srv.Handler)
@@ -28,7 +21,6 @@ var _ = Describe("Recovery", func() {
 	})
 
 	It("should support websockets and tracing", func() {
-		logrus.SetOutput(ioutil.Discard)
 		srv, err := createServer([]Option{WithRecovery(ioutil.Discard, true)})
 		Expect(err).NotTo(HaveOccurred())
 		ts := httptest.NewServer(srv.Handler)

--- a/http/recovery_test.go
+++ b/http/recovery_test.go
@@ -1,4 +1,4 @@
-package server_test
+package http
 
 import (
 	"io/ioutil"
@@ -8,8 +8,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-
-	. "github.com/contiamo/goserver/http"
 )
 
 var _ = Describe("Recovery", func() {

--- a/http/recovery_test.go
+++ b/http/recovery_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -13,6 +14,10 @@ import (
 var _ = Describe("Recovery", func() {
 	It("should be possible to configure panic recovery", func() {
 		logrus.SetOutput(ioutil.Discard)
+		defer func() {
+			logrus.SetOutput(os.Stdout)
+		}()
+
 		srv, err := createServer([]Option{WithRecovery(ioutil.Discard, true)})
 		Expect(err).NotTo(HaveOccurred())
 		ts := httptest.NewServer(srv.Handler)

--- a/http/server.go
+++ b/http/server.go
@@ -1,4 +1,4 @@
-package server
+package http
 
 import (
 	"context"

--- a/http/tracing.go
+++ b/http/tracing.go
@@ -1,4 +1,4 @@
-package server
+package http
 
 import (
 	"net/http"
@@ -106,7 +106,7 @@ func mwComponentName(componentName string) mwOption {
 // This can be overriden with options.
 //
 // Example:
-// 	 http.ListenAndServe("localhost:80", nethttp.Middleware(tracer, http.DefaultServeMux))
+//	 http.ListenAndServe("localhost:80", nethttp.Middleware(tracer, http.DefaultServeMux))
 //
 // The options allow fine tuning the behavior of the middleware.
 //
@@ -115,7 +115,7 @@ func mwComponentName(componentName string) mwOption {
 //      tracer,
 //      http.DefaultServeMux,
 //      netottp.OperationNameFunc(func(r *http.Request) string {
-//	        return "HTTP " + r.Method + ":/api/customers"
+//		return "HTTP " + r.Method + ":/api/customers"
 //      }),
 //      nethttp mwSpanObserver(func(sp opentracing.Span, r *http.Request) {
 //			sp.SetTag("http.uri", r.URL.EscapedPath())

--- a/http/tracing_test.go
+++ b/http/tracing_test.go
@@ -1,4 +1,4 @@
-package server_test
+package http
 
 import (
 	"net/http"
@@ -8,8 +8,6 @@ import (
 	. "github.com/onsi/gomega"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/mocktracer"
-
-	. "github.com/contiamo/goserver/http"
 )
 
 var _ = Describe("Tracing", func() {

--- a/test/utils.go
+++ b/test/utils.go
@@ -1,0 +1,41 @@
+package test
+
+import (
+	"bytes"
+	"io/ioutil"
+
+	"github.com/sirupsen/logrus"
+)
+
+// SetupLoggingBuffer creates an empty buffer and sets it
+// as a Logrus output globally. Returns the created buffer
+// so you can check what was logged.
+func SetupLoggingBuffer() (buf *bytes.Buffer, restore func()) {
+	buf = bytes.NewBuffer(nil)
+	std := logrus.StandardLogger()
+	prevFormatter, prevOut, prevLevel := std.Formatter, std.Out, std.Level
+	restore = func() {
+		logrus.SetFormatter(prevFormatter)
+		logrus.SetOutput(prevOut)
+		logrus.SetLevel(prevLevel)
+	}
+	logrus.SetFormatter(&logrus.TextFormatter{DisableColors: true})
+	logrus.SetOutput(buf)
+	logrus.SetLevel(logrus.DebugLevel)
+
+	return buf, restore
+}
+
+// DiscardLogging sets the global Logrus output to utils.Discard
+func DiscardLogging() (restore func()) {
+	std := logrus.StandardLogger()
+	prevOut, prevLevel := std.Out, std.Level
+	restore = func() {
+		logrus.SetOutput(prevOut)
+		logrus.SetLevel(prevLevel)
+	}
+
+	logrus.SetOutput(ioutil.Discard)
+	logrus.SetLevel(logrus.FatalLevel)
+	return restore
+}


### PR DESCRIPTION
Add logging and stacktrace on panic recovery
    
**What**
Now every time the grpc recovery middleware recovers from panic it logs the error message using logrus including the stacktrace.

**Why**
It was hard to troubleshoot panics because of the absence of the logs.

Also:
- I had to fix some tests to make them passing (had race conditions and false checks)
- I had to update a dependency to build the project (it was missing method)
- I changed the package names according to the common convention (directory=package name).