### PR TITLE
refactor Options interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ func main() {
     }),
     Options: []httpserver.Option{
       httpserver.WithLogging("http-echo"),
-      httpserver.WithTracing("localhost:6831", "example"),
+      httpserver.WithTracing("localhost:6831", "example", nil, nil),
       httpserver.WithMetrics("http-echo", nil),
       httpserver.WithRecovery(os.Stderr, true),
     },
@@ -93,7 +93,7 @@ func main() {
   }
 
   // start server
-  go httpServer.ListenAndServe(context.Background(), ":8000")
+  go httpserver.ListenAndServe(context.Background(), ":8000", httpServer)
   // start /metrics endpoint
   goserver.ListenAndServeMetricsAndHealth(":8080", nil)
 }

--- a/README.md
+++ b/README.md
@@ -98,3 +98,36 @@ func main() {
   goserver.ListenAndServeMetricsAndHealth(":8080", nil)
 }
 ```
+
+## Using goserver as Middleware
+It's not necessary to use goserver's server component. It is also possible to use it just as middleware in other servers. For example,
+to use goserver's recovery and logging middleware with [chi](https://github.com/go-chi/chi), you can do the following:
+```go
+package main
+
+import (
+  "io"
+  "net/http"
+
+  goserver "github.com/contiamo/goserver/http"
+
+  "github.com/go-chi/chi"
+)
+
+func main() {
+  r := chi.NewRouter()
+
+  // initialize goserver middleware
+  logging := goserver.WithLogging("application-name")
+  recovery := goserver.WithRecovery(os.Stderr, true)
+
+  // tell the chi router to use the goserver middleware
+  r.Use(logging.WrapHandler)
+  r.Use(recovery.WrapHandler)
+
+  // ... setup your routes and handlers...
+
+  // start the server
+  http.ListenAndServe(":8080", r)
+}
+```

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/prometheus/procfs v0.0.0-20180408092902-8b1c2da0d56d // indirect
 	github.com/rs/cors v1.3.0
 	github.com/sirupsen/logrus v1.0.5
+	github.com/stretchr/testify v1.3.0 // indirect
 	github.com/uber/jaeger-client-go v2.13.0+incompatible
 	github.com/uber/jaeger-lib v1.4.0 // indirect
 	github.com/urfave/negroni v0.3.0
@@ -30,7 +31,9 @@ require (
 	golang.org/x/net v0.0.0-20180418062111-d41e8174641f
 	golang.org/x/sys v0.0.0-20180419222023-a2a45943ae67 // indirect
 	golang.org/x/text v0.3.0 // indirect
-	google.golang.org/genproto v0.0.0-20180413175816-7fd901a49ba6 // indirect
+	google.golang.org/genproto v0.0.0-20180413175816-7fd901a49ba6
 	google.golang.org/grpc v1.11.3
+	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
+	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect
 	gopkg.in/yaml.v2 v2.2.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLM
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v0.0.0-20180328163153-e09c5db29600 h1:9JtpUrGhEHL+r4w4ahu0MxGWacOcA3TwaDKdukl3YBg=
 github.com/golang/protobuf v0.0.0-20180328163153-e09c5db29600/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/uuid v0.0.0-20161128191214-064e2069ce9c h1:jWtZjFEUE/Bz0IeIhqCnyZ3HG6KRXSntXe4SjtuTH7c=
@@ -30,6 +32,7 @@ github.com/opentracing/opentracing-go v1.0.2 h1:3jA2P6O1F9UOrWVpwrIo17pu01KWvNWg
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.0.0-20180416233856-82f5ff156b29 h1:cQm+HhVskQGWd5IRnRXnQgQ1yJK98jyeEy2uBi3OFlM=
 github.com/prometheus/client_golang v0.0.0-20180416233856-82f5ff156b29/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_model v0.0.0-20171117100541-99fa1f4be8e5 h1:cLL6NowurKLMfCeQy4tIeph12XNQWgANCNvdyrOYKV4=
@@ -42,6 +45,8 @@ github.com/rs/cors v1.3.0 h1:R0sy4XekGcOFoby9D76NXXg2birJ3WFkzGvXF9Kn3xE=
 github.com/rs/cors v1.3.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/sirupsen/logrus v1.0.5 h1:8c8b5uO0zS4X6RPl/sd1ENwSkIc0/H2PaHxE3udaE8I=
 github.com/sirupsen/logrus v1.0.5/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/uber/jaeger-client-go v2.13.0+incompatible h1:BQ7GxyS54wK+5kfRNoMVOhgQ7VAjhYlFq4rAhV7pnHc=
 github.com/uber/jaeger-client-go v2.13.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v1.4.0 h1:FiI99eCazm7u6tdv4Z+9sBXNrC9sHz43kfKIJaCDqCE=
@@ -60,6 +65,10 @@ google.golang.org/genproto v0.0.0-20180413175816-7fd901a49ba6 h1:VrRtqEIrO5wUzNw
 google.golang.org/genproto v0.0.0-20180413175816-7fd901a49ba6/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.11.3 h1:yy64MFk0j8qZbdXVA0MaSE+s/+6nCUdiyf1uNSjAz0c=
 google.golang.org/grpc v1.11.3/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
+gopkg.in/airbrake/gobrake.v2 v2.0.9 h1:7z2uVWwn7oVeeugY1DtlPAy5H+KYgB1KeKTnqjNatLo=
+gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 h1:OAj3g0cR6Dx/R07QgQe8wkA9RNjB2u4i700xBkIT4e0=
+gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/http/cors.go
+++ b/http/cors.go
@@ -28,12 +28,12 @@ type corsOption struct {
 	allowCredentials bool
 }
 
-func (opt *corsOption) WrapHandler(handler http.Handler) (http.Handler, error) {
+func (opt *corsOption) WrapHandler(handler http.Handler) http.Handler {
 	c := cors.New(cors.Options{
 		AllowedOrigins:   opt.allowedOrigins,
 		AllowedMethods:   opt.allowedMethods,
 		AllowedHeaders:   opt.allowedHeaders,
 		AllowCredentials: opt.allowCredentials,
 	})
-	return c.Handler(handler), nil
+	return c.Handler(handler)
 }

--- a/http/grpcweb.go
+++ b/http/grpcweb.go
@@ -14,7 +14,7 @@ func WithGRPC(srv *grpc.Server) Option {
 
 type grpcwebOption struct{ srv *grpc.Server }
 
-func (opt *grpcwebOption) WrapHandler(handler http.Handler) (http.Handler, error) {
+func (opt *grpcwebOption) WrapHandler(handler http.Handler) http.Handler {
 	wrappedGrpc := grpcweb.WrapServer(opt.srv)
 	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		if wrappedGrpc.IsGrpcWebRequest(req) {
@@ -22,5 +22,5 @@ func (opt *grpcwebOption) WrapHandler(handler http.Handler) (http.Handler, error
 			return
 		}
 		handler.ServeHTTP(resp, req)
-	}), nil
+	})
 }

--- a/http/logging.go
+++ b/http/logging.go
@@ -15,7 +15,7 @@ func WithLogging(app string) Option {
 
 type loggingOption struct{ app string }
 
-func (opt *loggingOption) WrapHandler(handler http.Handler) (http.Handler, error) {
+func (opt *loggingOption) WrapHandler(handler http.Handler) http.Handler {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		handler.ServeHTTP(w, r)
@@ -39,5 +39,5 @@ func (opt *loggingOption) WrapHandler(handler http.Handler) (http.Handler, error
 	})
 	n := negroni.New()
 	n.UseHandler(h)
-	return n, nil
+	return n
 }

--- a/http/recovery.go
+++ b/http/recovery.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/bakins/net-http-recover"
+	recovery "github.com/bakins/net-http-recover"
 )
 
 // WithRecovery configures panic recovery for that server
@@ -17,6 +17,6 @@ type recoveryOption struct {
 	printStack bool
 }
 
-func (opt *recoveryOption) WrapHandler(handler http.Handler) (http.Handler, error) {
-	return recovery.Handler(opt.writer, handler, opt.printStack), nil
+func (opt *recoveryOption) WrapHandler(handler http.Handler) http.Handler {
+	return recovery.Handler(opt.writer, handler, opt.printStack)
 }

--- a/http/server.go
+++ b/http/server.go
@@ -33,14 +33,10 @@ type Config struct {
 // srv.ListenAndServe(context.Background())
 func New(cfg *Config) (*http.Server, error) {
 	var (
-		h   = cfg.Handler
-		err error
+		h = cfg.Handler
 	)
 	for _, opt := range cfg.Options {
-		h, err = opt.WrapHandler(h)
-		if err != nil {
-			return nil, err
-		}
+		h = opt.WrapHandler(h)
 	}
 	return &http.Server{
 		Handler:        h,
@@ -68,5 +64,5 @@ func ListenAndServe(ctx context.Context, addr string, srv *http.Server) error {
 
 // Option is the interface for all server options defined in this package
 type Option interface {
-	WrapHandler(handler http.Handler) (http.Handler, error)
+	WrapHandler(handler http.Handler) http.Handler
 }


### PR DESCRIPTION
 - WrapHandler returns a new http.Handler only
 - The global tracer is initialized in WithTracing instead of WrapHandler
 - WithTracing can panic if invalid parameters are used
 - WithMetrics can panic if metrics cannot be registered