### PR TITLE
multi port instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 vendor
 /grpc/server.test
 /http/server.test
+
+.idea

--- a/README.md
+++ b/README.md
@@ -145,3 +145,19 @@ func main() {
   http.ListenAndServe(":8080", r)
 }
 ```
+
+To run the server and metrics on a different port:
+
+```
+  go func() {
+  	err := http.ListenAndServe(":8080", r)
+	if err != nil {
+		log.Fatal(err)
+	}
+  }()
+
+  err = goserver.ListenAndServeMetricsAndHealth(:8081, nil)
+  if err != nil {
+	log.Fatal(err)
+  }
+```


### PR DESCRIPTION
add instructions on how to run with different ports for health and metrics as they shouldn't be exposed externally